### PR TITLE
ルビのエスケープパターンを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jawn-to-ast",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jawn-to-ast",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Parse JAWN-FS to AST.",
   "author": "matori <pnr.matori@gmail.com>",
   "license": "MIT",

--- a/src/patterns.ts
+++ b/src/patterns.ts
@@ -20,7 +20,9 @@ const emphasisPatternBase = [
 ].join('');
 
 const rubyPatternBase = [
-  `(?<rubyBaseRaw>[${rubyBaseStartChars}](?<rubyBase>[^${escapeChars}]+?))`,
+  `(?<rubyBaseRaw>[${rubyBaseStartChars}]`,
+  `(?!${RUBY_TEXT_SYMBOL_START})`,
+  `(?<rubyBase>[^${escapeChars}]+?))`,
   `(?<!${RUBY_TEXT_SYMBOL_START})`,
   RUBY_TEXT_SYMBOL_START,
   `(?<rubyText>.+?)`,
@@ -32,5 +34,5 @@ const rubyPatternBase = [
 export const emphasisPattern = new RegExp(emphasisPatternBase, 'g');
 
 // `｜親文字《ルビ文字》` または `|親文字《ルビ文字》` にマッチする
-// /(?<rubyBaseRaw>[|｜](?<rubyBase>[^|｜]+?))(?<rubyTextRaw>(?<!《)《(?<rubyText>.+?)》)/g
+// /(?<rubyBaseRaw>[|｜](?!《)(?<rubyBase>[^|｜]+?))(?<rubyTextRaw>(?<!《)《(?<rubyText>.+?)》)/g
 export const rubyPattern = new RegExp(rubyPatternBase, 'g');

--- a/test/regexp-test.ts
+++ b/test/regexp-test.ts
@@ -213,6 +213,13 @@ describe('正規表現のテスト', function() {
           const matchedArray = [...matched];
           assert.strictEqual(matchedArray.length, 0);
         });
+
+        const sample4 = '|《春《は》る》';
+        it(sample4, function() {
+          const matched = sample4.matchAll(rubyPattern);
+          const matchedArray = [...matched];
+          assert.strictEqual(matchedArray.length, 0);
+        });
       });
 
       describe('ルビ親文字がない', function() {


### PR DESCRIPTION
`|《春《は》る》` がマッチしてしまうのを修正